### PR TITLE
onroadscreenoff with warning and alert

### DIFF
--- a/selfdrive/controls/lib/events.py
+++ b/selfdrive/controls/lib/events.py
@@ -187,7 +187,7 @@ class StartupAlert(Alert):
   def __init__(self, alert_text_1: str, alert_text_2: str = "保持手握方向盤並且注意路況", alert_status=AlertStatus.normal):
     super().__init__(alert_text_1, alert_text_2,
                      alert_status, AlertSize.mid,
-                     Priority.LOWER, VisualAlert.none, AudibleAlert.none, 10.),
+                     Priority.LOWER, VisualAlert.none, AudibleAlert.none, 0.),
 
 
 # ********** helper functions **********

--- a/selfdrive/ui/ui.cc
+++ b/selfdrive/ui/ui.cc
@@ -316,7 +316,7 @@ void Device::updateBrightness(const UIState &s) {
   int brightness = brightness_filter.update(clipped_brightness);
   if (!awake) {
     brightness = 0;
-  } else if (s.scene.started && interactive_timeout == 0 && s.scene.onroadScreenOff) {
+  } else if ((s.scene.started && interactive_timeout == 0 && s.scene.onroadScreenOff) && !(s.status == STATUS_WARNING || s.status == STATUS_ALERT)) {
     brightness = 0;
   }
 


### PR DESCRIPTION
    While onroadscreenoff is enabled , screen will remain off while warning and alert happened.

    This commit will light on the screen