### PR TITLE
Light screen on while warning and alert even onroadscreenoff enabled

### DIFF
--- a/selfdrive/ui/ui.cc
+++ b/selfdrive/ui/ui.cc
@@ -316,7 +316,10 @@ void Device::updateBrightness(const UIState &s) {
   int brightness = brightness_filter.update(clipped_brightness);
   if (!awake) {
     brightness = 0;
-  } else if (s.scene.started && interactive_timeout == 0 && s.scene.onroadScreenOff) {
+  } else if (s.status == STATUS_WARNING || s.status == STATUS_ALERT) {
+    // I feel more comfortable to keep screen 0.6 second on after warning and alert
+    interactive_timeout = 0.6 * UI_FREQ;
+  } else if (s.scene.started && interactive_timeout == 0 && s.scene.onroadScreenOff) {  
     brightness = 0;
   }
 


### PR DESCRIPTION
While onroadscreenoff is enabled , screen will remain off while warning and alert happened.

This commit will light on the screen and last for few second
