### PR TITLE
onroadscreenoff  with warning and alert

### DIFF
--- a/selfdrive/ui/ui.cc
+++ b/selfdrive/ui/ui.cc
@@ -316,7 +316,10 @@ void Device::updateBrightness(const UIState &s) {
   int brightness = brightness_filter.update(clipped_brightness);
   if (!awake) {
     brightness = 0;
-  } else if (s.scene.started && interactive_timeout == 0 && s.scene.onroadScreenOff) {
+  } else if (s.status == STATUS_WARNING || s.status == STATUS_ALERT) {
+    // I personal feel more comfortable to keep 0.5 second screen on after warning and alert
+    interactive_timeout = 0.5 * UI_FREQ;
+  } else if (s.scene.started && interactive_timeout == 0 && s.scene.onroadScreenOff) {  
     brightness = 0;
   }
 


### PR DESCRIPTION
While onroadscreenoff is enabled , this change will make screen on while warning and alert happened.