### PR TITLE
Screen off with warning and alert

### DIFF
--- a/selfdrive/ui/ui.cc
+++ b/selfdrive/ui/ui.cc
@@ -316,8 +316,13 @@ void Device::updateBrightness(const UIState &s) {
   int brightness = brightness_filter.update(clipped_brightness);
   if (!awake) {
     brightness = 0;
-  } else if (s.scene.started && interactive_timeout == 0 && s.scene.onroadScreenOff) {
-    brightness = 0;
+  } else if (s.scene.onroadScreenOff) {
+      if (s.status == STATUS_WARNING || s.status == STATUS_ALERT) {
+        // I personal feel more comfortable to keep 0.4 second screen on after warning and alert
+        interactive_timeout = 0.4 * UI_FREQ;
+      } else if (s.scene.started && interactive_timeout == 0 ) {  
+        brightness = 0;
+      }
   }
 
   if (brightness != last_brightness) {


### PR DESCRIPTION
modification to

1. enable screen warning and alert if screen-off function is toggled
2. performance tune for user not using screen-off function
3. prevent potential problem
4. less attraction impact period for driver (reduce period to  0.4 second)