### PR TITLE
fix C3 PATH_OFFSET lane_planner.py

### DIFF
--- a/selfdrive/controls/lib/lane_planner.py
+++ b/selfdrive/controls/lib/lane_planner.py
@@ -17,6 +17,7 @@ if EON:
   CAMERA_OFFSET = -0.06
 elif TICI:
   CAMERA_OFFSET = 0.04
+  PATH_OFFSET = 0.04
 else:
   CAMERA_OFFSET = 0.0
 


### PR DESCRIPTION
try to use PATH_OFFSET figure in ver 0.8.13
https://github.com/commaai/openpilot/blob/v0.8.13/selfdrive/controls/lib/lane_planner.py